### PR TITLE
#25: Use platform-specific path delimiter when constructing NODE_PATH.

### DIFF
--- a/tasks/protractor_coverage.js
+++ b/tasks/protractor_coverage.js
@@ -209,7 +209,7 @@ module.exports = function(grunt) {
       }
     // Spawn protractor command
     var done = this.async();
-    process.env["NODE_PATH"]=[process.env["NODE_PATH"],process.cwd()+'/node_modules'].join(':');
+    process.env["NODE_PATH"]=[process.env["NODE_PATH"],process.cwd()+'/node_modules'].join(path.delimiter);
     grunt.util.spawn({
         cmd: 'node',
         args: args,


### PR DESCRIPTION
`NODE_PATH` elements are currently always joined using `:` as a separator. This causes problems (#25) on windows, where path elements should be separated with ';' instead. This pull request attempts to solve this issue by using `path.delimiter` as the joining character.
