### PR TITLE
Extract the global coverage runner and configurable saveCoverage.tmpl path

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,8 @@ module.exports = function(grunt) {
         keepAlive: true, // If false, the grunt process stops when the test fails.
         noColor: false, // If true, protractor will not use colors in its output.
         coverageDir: 'coverage',
-        args: {}
+        args: {},
+        saveCoverageTemplate: "resources/saveCoverage.tmpl"
       },
       local: {
         options: {

--- a/resources/saveCoverage.tmpl
+++ b/resources/saveCoverage.tmpl
@@ -23,7 +23,8 @@ function saveCoverage(data){
   req.write('\n');
   req.end();
 }
-afterEach(function(){
+
+function runCoverageGlobal(){
   browser.driver.executeScript("return ('<%=coverage%>' in window)?window.<%=coverage%>:null;").then(function(val) {
     if (val) {
       saveCoverage(val);
@@ -31,4 +32,6 @@ afterEach(function(){
       console.warn('No coverage object in the browser.');
     }
   });
-});
+}
+
+afterEach(runCoverageGlobal);

--- a/tasks/protractor_coverage.js
+++ b/tasks/protractor_coverage.js
@@ -103,9 +103,10 @@ module.exports = function(grunt) {
       noColor: false,
       debug: false,
       collectorPort: 3001,
-      args: {}
-    });
-    var saveCoverageTemplate = grunt.file.expand(["resources/saveCoverage.tmpl", "node_modules/grunt-protractor-coverage/resources/saveCoverage.tmpl", process.cwd()+'/**/resources/saveCoverage.tmpl']).shift();
+      args: {},
+      saveCoverageTemplate: "resources/saveCoverage.tmpl"
+    });    
+    var saveCoverageTemplate = grunt.file.expand([ opts.saveCoverageTemplate, "node_modules/grunt-protractor-coverage/resources/saveCoverage.tmpl", process.cwd()+'/**/resources/saveCoverage.tmpl']).shift();
     if(!saveCoverageTemplate){
       grunt.fail.fatal("Coverage template file not found.");
     }

--- a/test/myTemplate.tmpl
+++ b/test/myTemplate.tmpl
@@ -1,0 +1,42 @@
+var fs=fs||require("fs");
+var http=http||require("http");
+var options = {
+  hostname: 'localhost',
+  port: <%=collectorPort%>,
+  path: '/data',
+  method: 'POST',
+  headers:{
+    'Content-Type':'application/json'
+  }
+};
+function saveCoverage(data){
+  var req = http.request(options, function(res) {
+      res.on('data', function (chunk) {
+      });
+  });
+  req.on('error', function(e) {
+    console.log('problem with request: ' + e.message);
+  });
+
+  // write data to request body
+  req.write(JSON.stringify(data));
+  req.write('\n');
+  req.end();
+}
+
+function runCoverageGlobal(){
+  browser.driver.executeScript("return ('<%=coverage%>' in window)?window.<%=coverage%>:null;").then(function(val) {
+    if (val) {
+      saveCoverage(val);
+    } else {
+      console.warn('No coverage object in the browser.');
+    }
+  });
+}
+
+afterEach(runCoverageGlobal);
+
+function ownFunction(){
+  /********  My own template file. Check /tmp/user/[id]/tmp_files  ************************/
+}
+


### PR DESCRIPTION
1) Extract the global coverage runner incase it needs to be run manually, like:

```
if (typeof runCoverageGlobal !== "undefined")
  runCoverageGlobal();
```

This is necessary before calling browser.refresh() or if there is any normal form posts to server.

2) Make the template file path configurable from the Gruntfile. Currently it looks at specific path: "resources/saveCoverage.tmpl"


