### PR TITLE
Provide noInject option to prevent altering Cucumber .feature files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,6 +64,12 @@ module.exports = function(grunt) {
           }
         }
       },
+      cucumber: {
+        options: {
+          configFile: "test/cucumber.conf.js",
+          noInject: true
+        }
+      }
     },
     copy: {
       'instrument': {
@@ -120,6 +126,7 @@ module.exports = function(grunt) {
   // plugin's task(s), then test the result.
   grunt.registerTask('test', ['clean', 'copy', 'instrument', 'connect:server', 'protractor_coverage:local', 'makeReport', 'coveralls']);
   grunt.registerTask('test-remote', ['clean', 'copy', 'instrument', 'connect:server', 'protractor_coverage:remote', 'makeReport', 'coveralls']);
+  grunt.registerTask('test-cucumber', ['clean', 'copy', 'instrument', 'connect:server', 'protractor_coverage:cucumber', 'makeReport', 'coveralls']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sources need to be instrumented using istanbul.
     instrument: {
         files: 'src/**/*.js',
         options: {
-        lazy: true,
+            lazy: true,
             basePath: "instrumented"
         }
     }
@@ -173,6 +173,39 @@ grunt.initConfig({
         }
     }
 });
+```
+
+### Cucumber tests
+grunt-protractor-coverage normally injects code used for obtaining coverage information by generating altered versions of spec files, but Cucumber features are written in Gherkin rather than JavaScript so this will fail. You can prevent this from happening using the noInject option:
+
+```js
+    protractor_coverage: {
+        options: {
+            keepAlive: true,
+            noInject: true,
+            coverageDir: 'path/to/coverage/dir',
+            args: {
+                baseUrl: 'http://localhost:9000'
+            }
+        },
+        local: {
+            options: {
+                configFile: 'path/to/protractor-local.conf.js'
+            }
+        }
+    }
+```
+
+Once enabled you'll also need to update your step definitions to store coverage data after each scenario runs: 
+
+```js
+var coverage = require('grunt-protractor-coverage/cucumber');
+
+module.exports = function () {
+    // Step definitions go here
+    
+    this.After(coverage.getCoverage);
+};
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -116,6 +116,39 @@ After the tests have been run and the coverage has been measured and captured yo
     }
 ```
 
+### Cucumber tests
+grunt-protractor-coverage normally injects code used for obtaining coverage information by generating altered versions of spec files, but Cucumber features are written in Gherkin rather than JavaScript so this will fail. You can prevent this from happening using the noInject option:
+
+```js
+    protractor_coverage: {
+        options: {
+            keepAlive: true,
+            noInject: true,
+            coverageDir: 'path/to/coverage/dir',
+            args: {
+                baseUrl: 'http://localhost:9000'
+            }
+        },
+        local: {
+            options: {
+                configFile: 'path/to/protractor-local.conf.js'
+            }
+        }
+    }
+```
+
+Once enabled you'll also need to update your step definitions to store coverage data after each scenario runs: 
+
+```js
+var coverage = require('grunt-protractor-coverage/cucumber');
+
+module.exports = function () {
+    // Step definitions go here
+    
+    this.After(coverage.getCoverage);
+};
+```
+
 ### Glue it all together!!
 
 ```js
@@ -173,39 +206,6 @@ grunt.initConfig({
         }
     }
 });
-```
-
-### Cucumber tests
-grunt-protractor-coverage normally injects code used for obtaining coverage information by generating altered versions of spec files, but Cucumber features are written in Gherkin rather than JavaScript so this will fail. You can prevent this from happening using the noInject option:
-
-```js
-    protractor_coverage: {
-        options: {
-            keepAlive: true,
-            noInject: true,
-            coverageDir: 'path/to/coverage/dir',
-            args: {
-                baseUrl: 'http://localhost:9000'
-            }
-        },
-        local: {
-            options: {
-                configFile: 'path/to/protractor-local.conf.js'
-            }
-        }
-    }
-```
-
-Once enabled you'll also need to update your step definitions to store coverage data after each scenario runs: 
-
-```js
-var coverage = require('grunt-protractor-coverage/cucumber');
-
-module.exports = function () {
-    // Step definitions go here
-    
-    this.After(coverage.getCoverage);
-};
 ```
 
 ## Contributing

--- a/cucumber/index.js
+++ b/cucumber/index.js
@@ -1,0 +1,37 @@
+var http = require('http');
+var options = {
+  hostname: 'localhost',
+  port: 3001,
+  path: '/data',
+  method: 'POST',
+  headers:{
+    'Content-Type':'application/json'
+  }
+};
+
+function saveCoverage(data){
+  var req = http.request(options, function(res) {
+    res.on('data', function (chunk) {
+    });
+  });
+  req.on('error', function(e) {
+    console.warn('Could not save coverage: ' + e.message);
+  });
+  req.write(JSON.stringify(data));
+  req.write('\n');
+  req.end();
+}
+
+function getCoverage(callback) {
+  browser.executeScript("return ('__coverage__' in window) ? window.__coverage__ : null;").then(function (coverage) {
+    if (coverage) {
+      saveCoverage(coverage);
+    }
+    callback();
+  });
+}
+
+module.exports = {
+  options: options,
+  getCoverage: getCoverage
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "tmp": "0.0.23"
   },
   "devDependencies": {
+    "cucumber": "^0.5.1",
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.11",
     "grunt-contrib-clean": "~0.4.0a",

--- a/test/cucumber.conf.js
+++ b/test/cucumber.conf.js
@@ -1,0 +1,21 @@
+exports.config = {
+  // The address of a running selenium server. If specified, Protractor will
+  // connect to an already running instance of selenium. This usually looks like
+  seleniumAddress: 'http://localhost:4444/wd/hub',
+  
+  // Spec patterns are relative to the location of this config.
+  specs: [
+    'test/features/*.feature'
+  ],
+
+  // A base URL for your application under test. Calls to protractor.get()
+  // with relative paths will be prepended with this.
+  baseUrl: 'http://localhost:3000/',
+
+  // Test framework to use. This may be one of:
+  // jasmine, jasmine2, cucumber, mocha or custom.
+  framework: 'cucumber',
+
+  // Options to be passed to Cucumber.
+  cucumberOpts: {}
+};

--- a/test/features/step_definitions/stepDefinitions.js
+++ b/test/features/step_definitions/stepDefinitions.js
@@ -1,0 +1,23 @@
+//var coverage = require('grunt-protractor-coverage/cucumber');
+var coverage = require('../../../cucumber');
+
+module.exports = function() {
+
+  this.After(coverage.getCoverage);
+
+  this.Given(/^(\d+) seconds? has passed$/, function (seconds) {
+    return browser.sleep(seconds * 1000);
+  });
+  
+  this.When(/^the user goes to the home page$/, function () {
+    return browser.driver.get(browser.baseUrl + '#');
+  });
+  
+  this.Then(/^the todo list is present$/, function () {
+    browser.waitForAngular();
+		return browser.wait(function() {
+			return element(by.id('new-todo')).isPresent();
+		});
+  });
+
+};

--- a/test/features/test.feature
+++ b/test/features/test.feature
@@ -1,0 +1,11 @@
+Feature: Plugin works
+
+  Scenario: It should not really do much
+    Given 3 seconds has passed
+    When the user goes to the home page
+    Then the todo list is present
+    
+  Scenario: It should continue doing nothing
+    Given 1 second has passed
+    When the user goes to the home page
+    Then the todo list is present


### PR DESCRIPTION
I've recently started using grunt-protractor-coverage with Cucumber style tests. Cucumber .feature files aren't written as JavaScript (they're plain text), so GPC fails when trying to rewrite them to call runCoverageGlobal.

To get around this, I've created a noInject option. When enabled GPC no longer tries to create these temporary rewritten features. I've also added a JS file that can be required from within the step definitions JS file and called to save coverage data - an example of it's use is provided in README.md

I'd welcome any comments/suggestions - thanks