### PR TITLE
fixes 'Fatal error: Coverage template file not found.' after using process.chdir

### DIFF
--- a/tasks/protractor_coverage.js
+++ b/tasks/protractor_coverage.js
@@ -94,7 +94,7 @@ module.exports = function(grunt) {
       args: {},
       saveCoverageTemplate: "resources/saveCoverage.tmpl"
     });    
-    var saveCoverageTemplate = grunt.file.expand([ opts.saveCoverageTemplate, "node_modules/grunt-protractor-coverage/resources/saveCoverage.tmpl", process.cwd()+'/**/resources/saveCoverage.tmpl']).shift();
+    var saveCoverageTemplate = grunt.file.expand([ opts.saveCoverageTemplate, "node_modules/grunt-protractor-coverage/resources/saveCoverage.tmpl", path.join(__dirname, '..') + '/**/resources/saveCoverage.tmpl']).shift();
     if(!saveCoverageTemplate){
       grunt.fail.fatal("Coverage template file not found.");
     }


### PR DESCRIPTION
After using [`process.chdir`](https://nodejs.org/api/process.html#process_process_chdir_directory) in order to change the current working directory of the process of the application being tested grunt-protractor-coverage doesn't find the template file _saveCoverage.tmpl_. Solved the issue by using a relative path.