### PR TITLE
Explicitly default keepAlive option to true.

### DIFF
--- a/tasks/protractor_coverage.js
+++ b/tasks/protractor_coverage.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var opts = this.options({
       configFile: (!grunt.util._.isUndefined(this.data.configFile)) ? this.data.configFile : protractorRefConfPath,
-      keepAlive: (!grunt.util._.isUndefined(this.data.keepAlive)) ? this.data.keepAlive : protractorRefConfPath,
+      keepAlive: (!grunt.util._.isUndefined(this.data.keepAlive)) ? this.data.keepAlive : true,
       noColor: false,
       noInject: false,
       debug: false,


### PR DESCRIPTION
By a simple mistake, the default value of the `keepAlive` option was set to a string (the default config file path), which acted as `true`. This patch sets it to true for clarity.