### PR TITLE
Update minimal nodejs version to 4.2.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ env:
   - secure: JrjTYKr32SadmQQGLl4aj6CnrUJuMGLOjEl6VjQWZEkgWU2+L7gdF09z1LbdsPh7Gz5/FnkRiYZTl5Ssl0gbY/F9veTGP4K+5MLYaOeFdZ6QJ6MAnFRKzwxSOqjgT9IrIknzojCi06I0VGyDFrrt9JhK+Sbx5Iv7koK76e2CpWE=
 language: node_js
 node_js:
-- '0.10'
+  - "4.2"
+  - "5"
 addons:
   sauce_connect:
     username:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "protractor": "^3.0.0"
   },
   "scripts": {
-    "test": "grunt clean jshint test-remote"
+    "test": "grunt clean jshint test-remote -v"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,32 +7,32 @@
     "test": "test"
   },
   "dependencies": {
-    "coverage-collector": "0.0.4",
+    "coverage-collector": "0.0.5",
     "dargs-object": "~0.2.0",
-    "escodegen": "~1.3.0",
-    "esprima": "~1.1.1",
-    "estraverse": "~1.5.0",
+    "escodegen": "~1.8.0",
+    "esprima": "~2.7.1",
+    "estraverse": "~4.1.1",
     "grunt": "^0.4.5",
-    "grunt-contrib-connect": "~0.7.1",
-    "grunt-istanbul": "~0.2.5",
-    "mkdirp": "~0.3.5",
+    "grunt-contrib-connect": "~0.11.2",
+    "grunt-istanbul": "~0.6.1",
+    "mkdirp": "~0.5.1",
     "temporary": "0.0.8",
-    "tmp": "0.0.23"
+    "tmp": "0.0.28"
   },
   "devDependencies": {
-    "cucumber": "^0.5.1",
+    "cucumber": "^0.9.2",
     "grunt": "~0.4.5",
-    "grunt-cli": "~0.1.11",
+    "grunt-cli": "~0.1.13",
     "grunt-contrib-clean": "~0.4.0a",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-jshint": "~0.1.0",
-    "grunt-contrib-nodeunit": "~0.1.0",
-    "grunt-coveralls": "~0.3.0",
-    "grunt-selenium-webdriver": "^0.2.451",
-    "protractor": "^1.0.0"
+    "grunt-contrib-copy": "~0.8.2",
+    "grunt-contrib-jshint": "~0.11.3",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt-coveralls": "~1.0.0",
+    "grunt-selenium-webdriver": "^0.2.482",
+    "protractor": "^3.0.0"
   },
   "scripts": {
-    "test": "grunt clean jshint test-remote -v"
+    "test": "grunt clean jshint test-remote"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "istanbul"
   ],
   "author": "ryan bridges",
-  "license": "APLv2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/r3b/grunt-protractor-coverage/issues"
   }


### PR DESCRIPTION
As of Protractor 3.0.0 any NodeJs version lower than 4.2 will not work anymore

see https://github.com/angular/protractor/blob/master/CHANGELOG.md#300

This pull request will also update the other dependencies.