### PR TITLE
Compatibility fix for protractor 3.3.0

### DIFF
--- a/cucumber/index.js
+++ b/cucumber/index.js
@@ -27,7 +27,7 @@ function getCoverage(callback) {
     if (coverage) {
       saveCoverage(coverage);
     }
-    callback();
+    typeof callback === 'function' && callback();
   });
 }
 


### PR DESCRIPTION
Considering that callback is not mandatory (even test step in the project itself doesn't provide it), it makes sense to only invoke the callback if it's a function.

For some reason it used to work just fine on the older protractor, but with protractor 3.3.0 this change is necessary for the plugin to work.
