### PR TITLE
Remove unndecessary grunt.expand where it might even hang the process

### DIFF
--- a/tasks/protractor_coverage.js
+++ b/tasks/protractor_coverage.js
@@ -102,11 +102,7 @@ module.exports = function(grunt) {
     var coverageDir = path.resolve(opts.coverageDir||'coverage/');
     coverageDir = coverageDir.replace(/\\/g,'/');
     var noInject = opts.noInject;
-    if (!noInject) {
-      saveCoverageTemplate = grunt.file.expand([ opts.saveCoverageTemplate, "node_modules/grunt-protractor-coverage/resources/saveCoverage.tmpl", process.cwd()+'/**/resources/saveCoverage.tmpl']).shift();
-      if(!saveCoverageTemplate){
-        grunt.fail.fatal("Coverage template file not found.");
-      }
+    if (!noInject) {      
       var saveCoverageSource = grunt.file.read(saveCoverageTemplate);
       var saveCoverageContent=grunt.template.process( saveCoverageSource, {
         data: {


### PR DESCRIPTION
* There is already a check for finding the saveCoverageTemplate and if it is not found the grunt task already would fail before coming to this section:

https://github.com/r3b/grunt-protractor-coverage/blob/master/tasks/protractor_coverage.js#L98

```
    var saveCoverageTemplate = grunt.file.expand([ opts.saveCoverageTemplate, "node_modules/grunt-protractor-coverage/resources/saveCoverage.tmpl", path.join(__dirname, '..') + '/**/resources/saveCoverage.tmpl']).shift();
    if(!saveCoverageTemplate){
      grunt.fail.fatal("Coverage template file not found.");
    }
```

*  Since the first element from the array is used from grunt.file.expand, it is at the very least found in the grunt-protractor-coverage node module, so the last statment is unnecessary

```
grunt.file.expand([ opts.saveCoverageTemplate, "node_modules/grunt-protractor-coverage/resources/saveCoverage.tmpl", process.cwd()+'/**/resources/saveCoverage.tmpl']).shift();
```

hence  the following is unnecessary
```
process.cwd()+'/**/resources/saveCoverage.tmpl' 
```

* The grunt task hangs sometimes because the project it is running under might be big. I debugged and find that it is hanging on the following line:

```
process.cwd()+'/**/resources/saveCoverage.tmpl' 
```
